### PR TITLE
BUG: Resolve Cross-Origin URL Error

### DIFF
--- a/src/components/messages/subComponents/Message.jsx
+++ b/src/components/messages/subComponents/Message.jsx
@@ -3,18 +3,9 @@ import { removeMessage } from "../../../firebase/firebaseMessages";
 import { Trash } from "react-bootstrap-icons";
 
 function Message({ id, message }) {
-  // Check if the response is a URL
-  const isUrl = (str) => {
-    try {
-      new URL(str);
-      return true;
-    } catch (_) {
-      // the (_) indicates that error is not used in catch (ignored)
-      return false;
-    }
-  };
+  const errorMessage = "That didn't go as planned";
 
-  return (
+  return message ? (
     <div key={id} className="message">
       <div className={`prompt ${message.agent.name}`}>
         <Trash
@@ -26,9 +17,11 @@ function Message({ id, message }) {
           {message.agent.name} Prompt: {message.prompt}
         </pre>
       </div>
+
       <div className={`response ${message.agent.name}`}>
         {message.agent.name} Response:{" "}
-        {isUrl(message.response) ? (
+        {message.response?.startsWith("data:image") ||
+        message.response?.startsWith("blob:http") ? (
           <img
             className="response-img"
             src={message.response}
@@ -39,6 +32,8 @@ function Message({ id, message }) {
         )}
       </div>
     </div>
+  ) : (
+    <div className="message-error">{errorMessage}</div>
   );
 }
 

--- a/src/components/messages/subComponents/TextInput.jsx
+++ b/src/components/messages/subComponents/TextInput.jsx
@@ -37,19 +37,11 @@ function TextInput({ show, dispatch, sidebar, agents }) {
         if (response) {
           let finalResponse = response;
 
-          // Check if the response is a URL
-          const isUrl = (str) => {
-            try {
-              new URL(str);
-              return true;
-            } catch (_) {
-              return false;
-            }
-          };
-
-          if (isUrl(response)) {
+          if (
+            response.startsWith("data:image") ||
+            response.startsWith("blob:http")
+          ) {
             finalResponse = await firebaseTxt2Img(response);
-            console.log("URL Test: ", isUrl(finalResponse))
           } else {
             response += await fetchModelResponse(
               sidebar.aiModel.title,


### PR DESCRIPTION
WHAT:
- The 'isUrl()' function returned true in some cases for standard text completion which filtered the text for a bad URL. On pull from Firebase this string would cause a Cross-Origin Request error

RESOLVED:
- now checking the text 2 image response using object.startsWith("data:image") || object.startsWith("blob:http") to ensure only image responses are filtered to a URL for Firebase
